### PR TITLE
Problem: ESTIMATE mark stops snapshot iteration too early

### DIFF
--- a/mvdata.go
+++ b/mvdata.go
@@ -177,7 +177,8 @@ func (d *GMVData[V]) SnapshotTo(cb func(Key, V) bool) {
 		}
 
 		if item.Estimate {
-			return true
+			// ignore ESTIMATE mark
+			return false
 		}
 
 		return cb(outer.Key, item.Value)


### PR DESCRIPTION
Solution:
- ignore estimate mark but keep the iteration.